### PR TITLE
Bump Setup Typst to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
       #   with:
       #     source_file: CockumberTheory/practice.typ
       - name: Setup typst
-        uses: yusancky/setup-typst@v2
+        uses: typst-community/setup-typst@v4
         id: setup-typst
         with:
-          version: 'v0.8.0'
+          typst-version: 'v0.8.0'
       - name: "Setup python"
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Bump [`typst-community/setup-typst`](https://github.com/typst-community/setup-typst) to v4

> [!IMPORTANT] 
> The action `yusancky/setup-typst` has officially been migrated to repository `typst-community/setup-typst`. See [announcement](https://github.com/yusancky/setup-typst/blob/main/announcement.md) for more information.